### PR TITLE
Exchange options

### DIFF
--- a/lib/exrabbit.ex
+++ b/lib/exrabbit.ex
@@ -185,6 +185,12 @@ defmodule Exrabbit.Utils do
 		exchange_declare_ok() = :amqp_channel.call channel, exchange.declare(exchange: exchange, type: "fanout", auto_delete: true)
 		exchange
 	end
+
+  def declare_exchange(channel, exchange, opts) when is_map(opts) do
+    opts = Enum.concat [exchange: exchange], opts
+    exchange_declare_ok() = :amqp_channel.call channel, exchange.declare.new(opts)
+    exchange
+  end
 	
 	def declare_exchange(channel, exchange, type, autodelete) do
 		exchange_declare_ok() = :amqp_channel.call channel, exchange_declare(exchange: exchange, type: type, auto_delete: autodelete)

--- a/lib/exrabbit/behaviour.ex
+++ b/lib/exrabbit/behaviour.ex
@@ -11,6 +11,10 @@ defmodule Exrabbit.Subscriber do
           {nil, nil} -> raise "You should either choose exchange or queue for rabbitmq subscription"
           {_, nil}   -> subscribe channel, args[:queue]
           {nil, _}   ->
+            case args[:exchange_opts] do
+              list -> declare_exchange channel, args[:exchange], args[:exchange_opts]
+              _ -> nil
+            end
             queue = declare_queue channel
             bind_queue channel, queue, args[:exchange]
             subscribe channel, queue 

--- a/lib/exrabbit/behaviour.ex
+++ b/lib/exrabbit/behaviour.ex
@@ -12,8 +12,8 @@ defmodule Exrabbit.Subscriber do
           {_, nil}   -> subscribe channel, args[:queue]
           {nil, _}   ->
             case args[:exchange_opts] do
+              nil -> nil
               list -> declare_exchange channel, args[:exchange], args[:exchange_opts]
-              _ -> nil
             end
             queue = declare_queue channel
             bind_queue channel, queue, args[:exchange]


### PR DESCRIPTION
Support declaring an exchange with options as a map to support more complex exchange usages. Allow consumer of the behaviour to pass args[:exchange_opts] to cause the declaration of an exchange with the specified options, so the application can create the exchange automatically if necessary.
